### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,26 +6,26 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-MyRobot 			KEYWORD1
+MyRobot	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-servos 		 				KEYWORD2
-stopServo					KEYWORD2
-goAhead 					KEYWORD2
-goBack  					KEYWORD2
-goBackRight					KEYWORD2
-goBackLeft					KEYWORD2
-analogSensors 	 			KEYWORD2
-digitalSensors 				KEYWORD2
-getDigitalRead				KEYWORD2
-getAnalogRead				KEYWORD2
-ultra		  				KEYWORD2
-getDistancia  				KEYWORD2
-toggleRight					KEYWORD2
-toggleLeft					KEYWORD2
+servos	KEYWORD2
+stopServo	KEYWORD2
+goAhead	KEYWORD2
+goBack	KEYWORD2
+goBackRight	KEYWORD2
+goBackLeft	KEYWORD2
+analogSensors	KEYWORD2
+digitalSensors	KEYWORD2
+getDigitalRead	KEYWORD2
+getAnalogRead	KEYWORD2
+ultra	KEYWORD2
+getDistancia	KEYWORD2
+toggleRight	KEYWORD2
+toggleLeft	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords